### PR TITLE
Fixed a problem with environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,15 @@ function processSingleProp(prop, serviceProperties){
       if (Object.getOwnPropertyNames(objectKey).length) {
         // Object entry -> iterate and build props
         ymlFragment = ymlFragment.concat("  ").concat(prop + ':\n');
+        // Some props are using another concat instead of : for composing the values
+        // For this we are using the variable _concatFragment
+        var _concatFragment = ":";
+        if(prop == "environment"){
+          _concatFragment = "=";
+        };
         for (let envJSONKey of Object.getOwnPropertyNames(objectKey)) {
           let objValue = objectKey[envJSONKey];
-          ymlFragment = ymlFragment.concat("   - ").concat(envJSONKey).concat(":").concat(objValue).concat('\n') ;
+          ymlFragment = ymlFragment.concat("   - ").concat(envJSONKey).concat(_concatFragment).concat(objValue).concat('\n') ;
         }
       };
     } else {

--- a/tests/10_output.yml
+++ b/tests/10_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -14,8 +14,8 @@ service:
    - 8080
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/11_output.yml
+++ b/tests/11_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -11,8 +11,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/12_output.yml
+++ b/tests/12_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -12,8 +12,8 @@ service:
   command: bundle exec thin -p 3000
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/14_output.yml
+++ b/tests/14_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -14,8 +14,8 @@ service:
    - 127.0.0.1
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/15_output.yml
+++ b/tests/15_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -11,8 +11,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/16_output.yml
+++ b/tests/16_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -17,8 +17,8 @@ service:
    - dc2.example.com
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/17_output.yml
+++ b/tests/17_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -19,8 +19,8 @@ service:
   memswap_limit: 128k
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/1_output.yml
+++ b/tests/1_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -13,8 +13,8 @@ service:
    - /home/someuser/test:/var/www/test
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/2_output.yml
+++ b/tests/2_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/3_output.yml
+++ b/tests/3_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/4_output.yml
+++ b/tests/4_output.yml
@@ -8,8 +8,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/5_output.yml
+++ b/tests/5_output.yml
@@ -8,8 +8,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/6_output.yml
+++ b/tests/6_output.yml
@@ -1,15 +1,15 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   ports:
    - 3456
    - 8692
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/7_output.yml
+++ b/tests/7_output.yml
@@ -1,15 +1,15 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   ports:
    - 3456
    - 8692
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/8_output.yml
+++ b/tests/8_output.yml
@@ -1,15 +1,15 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/cpu_shares_output_1.yml
+++ b/tests/cpu_shares_output_1.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -20,8 +20,8 @@ service:
   cpu_shares: 43
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/mem_limit_1.yml
+++ b/tests/mem_limit_1.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -12,8 +12,8 @@ service:
   mem_limit: 256M
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/memswap_limit_1.yml
+++ b/tests/memswap_limit_1.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -13,8 +13,8 @@ service:
   memswap_limit: 128m
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/volumes_misising_value.yml
+++ b/tests/volumes_misising_value.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -11,8 +11,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4

--- a/tests/volumes_output.yml
+++ b/tests/volumes_output.yml
@@ -1,7 +1,7 @@
 service:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4
@@ -11,8 +11,8 @@ service:
   image: tudvari.com:5000/warper/ms_config:LATEST
 service2:
   environment:
-   - WARPER_PORT:1234
-   - WARPER_IP:127.0.0.1
+   - WARPER_PORT=1234
+   - WARPER_IP=127.0.0.1
   extra_hosts:
    - amqphost:10.0.0.4
    - mongohost:10.0.0.4


### PR DESCRIPTION
Fixed a problem with latest version of docker compose. It seems that environment variables are delimited by `=` instead of `:`.

This pull request fixed this issue and added a way to implement a failsafe for those kind of values