### PR TITLE
Add support to "name attribute"

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -279,7 +279,7 @@
         "type": ["object", "null"],
         "properties": {
           "driver": {"type": "string"},
-          "name":{"type":"string"},
+          "name": {"type":"string"},
           "driver_opts": {
             "type": "object",
             "patternProperties": {


### PR DESCRIPTION
The default schema.json did not support the "name" attribute in docker-compose network definition. 
This quick PR add this support