### PR TITLE
add attachable to non ipam config

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -286,6 +286,7 @@
               "^.+$": {"type": ["string", "number"]}
             }
           },
+          "attachable": {"type": "boolean"},
           "ipam": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Hey I did not check https://github.com/tudvari/docker-composer/issues/132 on time sorry. 
Thanks for the implementation of IPAM ! 

However, I still need the support of "attachable" in a non ipam network config :) 

Please find the associated PR :) 